### PR TITLE
Delete user

### DIFF
--- a/scripts/customer/deleteUser.py
+++ b/scripts/customer/deleteUser.py
@@ -1,0 +1,91 @@
+# Sierra Yerges
+import os
+import pandas as pd
+from Crypto.PublicKey import ECC
+
+# Define CSV file paths
+customers_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../csvFiles/customers.csv'))
+employees_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../csvFiles/employees.csv'))
+persons_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../csvFiles/persons.csv'))
+accounts_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../csvFiles/accounts.csv'))
+bills_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../csvFiles/bills.csv'))
+
+
+def delete_user_button_pressed(user_type: str, user_id: int, password: str = None, is_admin: bool = False) -> dict:
+    """
+    Deletes a customer or teller account if they have no active accounts or bills.
+    Admins can bypass password checks. Associated .pem key file is deleted if present.
+
+    Parameters
+    ----------
+    user_type : str
+        'Customer', 'Teller', or 'Admin'.
+    user_id : int
+        ID of the user to delete.
+    password : str, optional
+        Password to decrypt the private key (required for non-admins).
+    is_admin : bool
+        Whether the deletion is performed by an admin.
+
+    Returns
+    -------
+    dict
+        A result dictionary with status and message.
+    """
+
+    # Load CSVs
+    try:
+        persons_df = pd.read_csv(persons_path)
+        accounts_df = pd.read_csv(accounts_path)
+        bills_df = pd.read_csv(bills_path)
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to load required files: {e}"}
+
+    # Check for active accounts or bills
+    if not accounts_df[accounts_df['CustomerID'] == user_id].empty \
+       or not bills_df[bills_df['CustomerID'] == user_id].empty:
+        return {"status": "error", "message": "User cannot be deleted. Active accounts or bills still exist."}
+
+    # Password verification (non-admins only)
+    if not is_admin:
+        key_path = f"{user_id}privatekey.pem"
+        if not os.path.exists(key_path):
+            return {"status": "error", "message": "Private key file not found."}
+        try:
+            with open(key_path, 'rt') as f:
+                ECC.import_key(f.read(), passphrase=password)
+        except Exception:
+            return {"status": "error", "message": "Incorrect password. Private key decryption failed."}
+
+    # Remove from persons.csv
+    persons_df = persons_df[persons_df['ID'] != user_id]
+    try:
+        persons_df.to_csv(persons_path, index=False)
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to update persons.csv: {e}"}
+
+    # Remove from customer or employee file
+    if user_type == 'Customer':
+        try:
+            cust_df = pd.read_csv(customers_path)
+            cust_df = cust_df[cust_df['CustomerID'] != user_id]
+            cust_df.to_csv(customers_path, index=False)
+        except Exception as e:
+            return {"status": "error", "message": f"Failed to update customers.csv: {e}"}
+    elif user_type == 'Teller':
+        try:
+            emp_df = pd.read_csv(employees_path)
+            emp_df = emp_df[emp_df['EmployeeID'] != user_id]
+            emp_df.to_csv(employees_path, index=False)
+        except Exception as e:
+            return {"status": "error", "message": f"Failed to update employees.csv: {e}"}
+
+    # Delete PEM key file
+    pem_path = f"{user_id}privatekey.pem"
+    if os.path.exists(pem_path):
+        try:
+            os.remove(pem_path)
+        except Exception as e:
+            return {"status": "error", "message": f"Failed to delete PEM file: {e}"}
+
+    return {"status": "success", "message": f"{user_type} account {user_id} successfully deleted."}

--- a/tests/test_deleteUser.py
+++ b/tests/test_deleteUser.py
@@ -1,0 +1,177 @@
+# Sierra Yerges
+# In root dir: python -m unittest tests/test_deleteUser.py
+import unittest
+from unittest.mock import patch, mock_open
+import pandas as pd
+from scripts.customer.deleteUser import delete_user_button_pressed
+
+class TestDeleteUserFunction(unittest.TestCase):
+    """
+    Unit tests for delete_user_button_pressed function.
+
+    These tests verify:
+    - Proper deletion of customers or tellers under valid conditions.
+    - Prevention of deletion with active accounts or bills.
+    - Password verification using ECC key decryption.
+    - Admin privileges bypass password check.
+    - Cleanup of CSVs and private key (.pem) files.
+    """
+
+    @patch("scripts.customer.deleteUser.os.path.exists")
+    @patch("scripts.customer.deleteUser.os.remove")
+    @patch("scripts.customer.deleteUser.pd.read_csv")
+    @patch("scripts.customer.deleteUser.pd.DataFrame.to_csv")
+    @patch("scripts.customer.deleteUser.ECC.import_key")
+    def test_customer_deletion_success(self, mock_import, mock_to_csv, mock_read_csv, mock_remove, mock_exists):
+        """
+        Test successful deletion of a customer with no active accounts or bills and valid password.
+        """
+        # Simulate all required files and PEM file existing
+        mock_exists.side_effect = lambda path: True if path.endswith("privatekey.pem") or ".csv" in path else False
+
+        # Provide mock data
+        mock_read_csv.side_effect = [
+            pd.DataFrame([{"ID": 111, "UserType": "Customer"}]),  # persons.csv
+            pd.DataFrame(columns=["AccountID", "CustomerID"]),    # accounts.csv (empty)
+            pd.DataFrame(columns=["BillID", "CustomerID"]),       # bills.csv (empty)
+            pd.DataFrame([{"CustomerID": 111}])                   # customers.csv
+        ]
+
+        # Simulate successful private key decryption
+        with patch("builtins.open", mock_open(read_data="ECC KEY")):
+            result = delete_user_button_pressed("Customer", 111, password="validpass", is_admin=False)
+
+        # Assert successful deletion
+        self.assertEqual(result["status"], "success")
+        self.assertIn("successfully deleted", result["message"])
+        mock_import.assert_called_once()
+        mock_to_csv.assert_called()
+        mock_remove.assert_called()
+
+    @patch("scripts.customer.deleteUser.os.path.exists")
+    @patch("scripts.customer.deleteUser.os.remove")
+    @patch("scripts.customer.deleteUser.pd.read_csv")
+    @patch("scripts.customer.deleteUser.pd.DataFrame.to_csv")
+    def test_admin_deletes_teller_successfully(self, mock_to_csv, mock_read_csv, mock_remove, mock_exists):
+        """
+        Test that an admin can delete a teller account if no accounts or bills are linked.
+        """
+        mock_exists.side_effect = lambda path: True if path.endswith("privatekey.pem") or ".csv" in path else False
+
+        mock_read_csv.side_effect = [
+            pd.DataFrame([{"ID": 888, "UserType": "Teller"}]),     # persons.csv
+            pd.DataFrame(columns=["AccountID", "CustomerID"]),     # accounts.csv
+            pd.DataFrame(columns=["BillID", "CustomerID"]),        # bills.csv
+            pd.DataFrame([{"EmployeeID": 888}])                    # employees.csv
+        ]
+
+        result = delete_user_button_pressed("Teller", 888, is_admin=True)
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("successfully deleted", result["message"])
+        mock_to_csv.assert_called()
+        mock_remove.assert_called()
+
+    @patch("scripts.customer.deleteUser.pd.read_csv")
+    def test_deletion_fails_with_active_accounts(self, mock_read_csv):
+        """
+        Test user cannot be deleted if they have active accounts.
+        """
+        mock_read_csv.side_effect = [
+            pd.DataFrame([{"ID": 222, "UserType": "Customer"}]),   # persons.csv
+            pd.DataFrame([{"AccountID": 1, "CustomerID": 222}]),   # accounts.csv
+            pd.DataFrame(columns=["BillID", "CustomerID"])         # bills.csv
+        ]
+
+        result = delete_user_button_pressed("Customer", 222, password="pass", is_admin=False)
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Active accounts", result["message"])
+
+    @patch("scripts.customer.deleteUser.os.path.exists", return_value=False)
+    @patch("scripts.customer.deleteUser.pd.read_csv")
+    def test_missing_key_file(self, mock_read_csv, mock_exists):
+        """
+        Test customer deletion fails if PEM key file does not exist.
+        """
+        mock_read_csv.side_effect = [
+            pd.DataFrame([{"ID": 333, "UserType": "Customer"}]),
+            pd.DataFrame(columns=["AccountID", "CustomerID"]),
+            pd.DataFrame(columns=["BillID", "CustomerID"])
+        ]
+
+        result = delete_user_button_pressed("Customer", 333, password="any", is_admin=False)
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Private key file not found", result["message"])
+
+    @patch("scripts.customer.deleteUser.os.path.exists", return_value=True)
+    @patch("scripts.customer.deleteUser.pd.read_csv")
+    @patch("scripts.customer.deleteUser.ECC.import_key", side_effect=ValueError("Decryption failed"))
+    def test_incorrect_password(self, mock_import, mock_read_csv, mock_exists):
+        """
+        Test decryption failure due to incorrect password blocks deletion.
+        """
+        mock_read_csv.side_effect = [
+            pd.DataFrame([{"ID": 444}]),
+            pd.DataFrame(columns=["AccountID", "CustomerID"]),
+            pd.DataFrame(columns=["BillID", "CustomerID"])
+        ]
+
+        with patch("builtins.open", mock_open(read_data="ECC KEY")):
+            result = delete_user_button_pressed("Customer", 444, password="wrong", is_admin=False)
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("decryption failed", result["message"])
+
+    @patch("scripts.customer.deleteUser.os.path.exists", return_value=True)
+    @patch("scripts.customer.deleteUser.os.remove")
+    @patch("scripts.customer.deleteUser.pd.read_csv")
+    @patch("scripts.customer.deleteUser.pd.DataFrame.to_csv")
+    def test_admin_can_delete_without_password(self, mock_to_csv, mock_read_csv, mock_remove, mock_exists):
+        """
+        Test that admin can delete customer without password verification.
+        """
+        mock_read_csv.side_effect = [
+            pd.DataFrame([{"ID": 555, "UserType": "Customer"}]),
+            pd.DataFrame(columns=["AccountID", "CustomerID"]),
+            pd.DataFrame(columns=["BillID", "CustomerID"]),
+            pd.DataFrame([{"CustomerID": 555}])
+        ]
+
+        result = delete_user_button_pressed("Customer", 555, is_admin=True)
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("successfully deleted", result["message"])
+        mock_to_csv.assert_called()
+        mock_remove.assert_called()
+
+    @patch("scripts.customer.deleteUser.os.path.exists")
+    @patch("scripts.customer.deleteUser.os.remove")
+    @patch("scripts.customer.deleteUser.pd.read_csv")
+    @patch("scripts.customer.deleteUser.pd.DataFrame.to_csv")
+    @patch("scripts.customer.deleteUser.ECC.import_key")
+    def test_teller_deletes_customer_with_password(self, mock_import, mock_to_csv, mock_read_csv, mock_remove, mock_exists):
+        """
+        Test that a teller (non-admin) can delete a customer account with a valid password.
+        """
+        mock_exists.side_effect = lambda path: True if path.endswith("privatekey.pem") or ".csv" in path else False
+
+        mock_read_csv.side_effect = [
+            pd.DataFrame([{"ID": 777, "UserType": "Customer"}]),
+            pd.DataFrame(columns=["AccountID", "CustomerID"]),
+            pd.DataFrame(columns=["BillID", "CustomerID"]),
+            pd.DataFrame([{"CustomerID": 777}])
+        ]
+
+        with patch("builtins.open", mock_open(read_data="ECC KEY")):
+            result = delete_user_button_pressed("Customer", 777, password="correctpass", is_admin=False)
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("successfully deleted", result["message"])
+        mock_import.assert_called_once()
+        mock_to_csv.assert_called()
+        mock_remove.assert_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
delete customer or teller account:
-     Deletes a customer or teller account if they have no active accounts or bills.
-     Admins can bypass password checks. Associated .pem key file is deleted if present.


unit test script:
    - Proper deletion of customers or tellers under valid conditions.
    - Prevention of deletion with active accounts or bills.
    - Password verification using ECC key decryption.
    - Admin privileges bypass password check.
    - Cleanup of CSVs and private key (.pem) files.