### PR TITLE
Fixed transaction log

### DIFF
--- a/app/static/js/view-transactions.js
+++ b/app/static/js/view-transactions.js
@@ -24,7 +24,7 @@ function loadTransactions(accountId, accountType) {
         } else {
           data.transactions.forEach(txn => {
             const li = document.createElement("li");
-            li.textContent = `${txn.TransDate} | ${txn.TransType} | $${txn.Amount}`;
+            li.textContent = `${txn.TransDate} | ${txn.TransactionType} | $${txn.Amount}`;
             list.appendChild(li);
           });
         }

--- a/scripts/makeDeposit.py
+++ b/scripts/makeDeposit.py
@@ -114,7 +114,7 @@ def deposit(accID, amount) -> dict:
         else:
             transaction_type = 'Payment to Mortgage Loan'
     else:
-        transaction_type = 'Deposit to account'
+        transaction_type = 'Deposit'
     
     currentBal += Decimal(amount).quantize(Decimal('0.00'))
     accInfo['CreditLimit'] = accInfo['CreditLimit'].apply(lambda x: Decimal(str(x)).quantize(Decimal('0.00')))


### PR DESCRIPTION
Transaction log used to show 'undefined' when viewing the transactions on an account
![image](https://github.com/user-attachments/assets/f030ad2e-f291-4f5f-851a-1219b1351a68)

Now shows the correct transaction type
<img width="251" alt="image" src="https://github.com/user-attachments/assets/ba156dd0-e91c-4fc4-aa86-a85a28f989af" />


Also changed the transaction type from 'Deposit to account' to just 'Deposit'